### PR TITLE
feat(ui): add CRT monitor filter effect for authentic retro experience

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -17,7 +17,9 @@ import { Font } from 'astro:assets';
     <Font cssVariable='--font-lucida' preload />
 	</head>
 	<body>
-		<slot />
+		<div class="crt_filter"></div>
+			<slot />
+		
 	</body>
 </html>
 
@@ -31,4 +33,38 @@ import { Font } from 'astro:assets';
 		user-select: none;
   		-webkit-user-select: none;
 	}
+
+	.crt_filter {
+  position: fixed;
+  z-index: 1000;
+  height: 100%;
+  width: 100%;
+  background: linear-gradient(to top, #000000, #000000, #333333, #333333);
+  background-size: cover;
+  background-size: 100% 5px;
+  opacity: 0.05;
+  pointer-events: none;
+}
+
+.crt_filter.off {
+  display: none;
+}
+
+@media screen {
+  .crt_filter {
+    animation: scanlines infinite 50s linear;
+  }
+}
+@keyframes scanlines {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 0 -10px;
+  }
+}
+
+.crt_filter.off {
+  display: none;
+}
 </style>


### PR DESCRIPTION
- Implement CRT filter overlay with scanline animation
- Add subtle gradient background effect simulating CRT monitor
- Include animated scanlines with 50-second linear animation
- Apply fixed positioning with high z-index for proper layering
- Set low opacity (0.05) for subtle authentic CRT appearance
- Disable pointer events to maintain interactivity
- Add CSS keyframes for smooth scanline movement
- Enhance Windows 95 desktop with period-appropriate monitor styling